### PR TITLE
replaced 'archive.tar.gz' with 'archive-{hash}.tar.gz' 

### DIFF
--- a/ubr/conf.py
+++ b/ubr/conf.py
@@ -1,7 +1,7 @@
 import logging
 from pythonjsonlogger import jsonlogger
-from ubr import utils
-
+#from ubr import utils # DONT!
+        
 ROOTLOG = logging.getLogger("")
 _supported_keys = [
     #'asctime',
@@ -29,14 +29,31 @@ _formatter = jsonlogger.JsonFormatter(_log_format)
 
 # output to stderr
 _handler = logging.StreamHandler()
-_handler.setLevel(logging.INFO)
+_handler.setLevel(logging.DEBUG)
 _handler.setFormatter(logging.Formatter('%(levelname)s - %(asctime)s - %(message)s'))
 
 ROOTLOG.addHandler(_handler)
 ROOTLOG.setLevel(logging.DEBUG)
 
+# tell boto to pipe down
+import boto3
+boto3.set_stream_logger('', logging.CRITICAL)
+
 BUCKET = 'elife-app-backups'
 CONFIG_DIR = '/etc/ubr/'
 
 RESTORE_DIR = '/tmp/ubr/' # which dir to download files to and restore from
-utils.mkdir_p(RESTORE_DIR)
+
+# duplicated from utils
+def mkdir_p(path):
+    import os, errno
+    try:
+        os.makedirs(path)
+    except OSError as err:
+        if err.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            ROOTLOG.error("problem attempting to create path %s: %s", path, err)
+            raise
+
+mkdir_p(RESTORE_DIR)

--- a/ubr/tests/test_tgz_target.py
+++ b/ubr/tests/test_tgz_target.py
@@ -1,5 +1,6 @@
 import os
-from ubr import main
+import glob
+from ubr import main, tgz_target
 from base import BaseCase
 
 class TestTarredGzippedBackup(BaseCase):
@@ -7,16 +8,18 @@ class TestTarredGzippedBackup(BaseCase):
         self.expected_output_dir = '/tmp/foo'
 
     def tearDown(self):
-        os.system('rm /tmp/foo/archive.tar.gz')
+        os.system('rm /tmp/foo/archive.*.tar.gz')
 
     def test_simple_tgz(self):
         fixture = os.path.join(self.fixture_dir, 'img1.png')
-        descriptor = {'tar-gzipped': [fixture, os.path.join(self.fixture_dir, '*/**')]}
+        paths = [fixture, os.path.join(self.fixture_dir, '*/**')]
+        descriptor = {'tar-gzipped': paths}
         output = main.backup(descriptor, output_dir=self.expected_output_dir)
 
+        filename = tgz_target.filename_for_paths(paths)
         expected_output = {
             'tar-gzipped': {
-                'output': [os.path.join(self.expected_output_dir, 'archive.tar.gz')]}}
+                'output': [os.path.join(self.expected_output_dir, filename + '.tar.gz')]}}
         self.assertEqual(output, expected_output)
         # test all of the files exist
         for path in output['tar-gzipped']['output']:
@@ -34,18 +37,27 @@ class TestTarredGzippedRestore(BaseCase):
         self.expected_output_dir = '/tmp/baz'
 
     def tearDown(self):
-        os.system('rm %s' % os.path.join(self.expected_output_dir, 'archive.tar.gz'))
+        archive_files = glob.glob(os.path.join(self.expected_output_dir, 'archive-*'))
+        map(lambda path: os.system('rm ' + path), archive_files)
 
     def test_tgz_restore(self):
         "tar-gzipped target unpacks the backup and restores the files"
         fixture = os.path.join(self.fixture_dir, 'img1.png')
-        descriptor = {'tar-gzipped': [fixture]}
+        paths = [fixture]
+        descriptor = {'tar-gzipped': paths}
         main.backup(descriptor, output_dir=self.expected_output_dir)
-        # ensure an archive was created
-        self.assertTrue(os.path.isfile(os.path.join(self.expected_output_dir, 'archive.tar.gz')))
 
+        # ensure an archive was created
+        filename = tgz_target.filename_for_paths(paths)
+        expected_path = os.path.join(self.expected_output_dir, filename + '.tar.gz')
+        self.assertTrue(os.path.isfile(expected_path))
+
+        # ensure we get the expected output
         expected_results = {
-            'tar-gzipped': {'output': [(os.path.abspath(fixture), True)]}}
+            'tar-gzipped': {
+                # a list of absolute paths-to-files (single file in our case)
+                'output': [(os.path.abspath(fixture), True)]
+            }
+        }
         results = main.restore(descriptor, backup_dir=self.expected_output_dir)
         self.assertEqual(results, expected_results)
-

--- a/ubr/utils.py
+++ b/ubr/utils.py
@@ -1,12 +1,12 @@
 import os
-import logging
 from datetime import datetime
 import errno
 from itertools import takewhile
 import compiler.ast
 import hashlib
+from conf import logging
 
-logger = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
 
 flatten = compiler.ast.flatten # deprecated, removed in Python3
 
@@ -24,9 +24,9 @@ def env(nom):
     return os.environ.get(nom, None)
 
 def system(cmd):
-    logger.info(cmd)
+    LOG.info(cmd)
     retval = os.system(cmd)
-    logger.info("return status %s", retval)
+    LOG.info("return status %s", retval)
     return retval
 
 def mkdir_p(path):
@@ -36,7 +36,7 @@ def mkdir_p(path):
         if exc.errno == errno.EEXIST and os.path.isdir(path):
             pass
         else:
-            logger.error("problem attempting to create path %s", path)
+            LOG.error("problem attempting to create path %s", path)
             raise
 
 def dir_exists(p):


### PR DESCRIPTION
this is so multiple descriptors on a machine don't conflict. the hash is derived from the list of paths that are being backed up and only the first 8 bytes of the hexdigest are being used