### PR TITLE
donotmerge, feat remove config dir

### DIFF
--- a/project_tests.sh
+++ b/project_tests.sh
@@ -2,7 +2,7 @@
 set -e
 
 # new-style config (see libraries formula)
-rm app.cfg
+rm -f app.cfg
 cp /etc/ubr-test-app.cfg app.cfg
 
 # legacy config

--- a/ubr.sh
+++ b/ubr.sh
@@ -5,4 +5,4 @@ set -e
 . install.sh > /dev/null
 
 # usage: ubr <config-dir> <backup|restore> <dir|s3> [target] [path]
-python -m ubr.main /etc/ubr/ "$@"
+python -m ubr.main "$@"

--- a/ubr/descriptions.py
+++ b/ubr/descriptions.py
@@ -4,7 +4,7 @@ from utils import ensure, unique
 from functools import partial
 import yaml
 from schema import Schema, SchemaError
-import logging
+from conf import logging
 
 LOG = logging.getLogger(__name__)
 
@@ -72,8 +72,8 @@ def validate_descriptor(descriptor):
     except SchemaError as err:
         raise AssertionError(str(err))
 
-def load_descriptor(descriptor, path_list=[]):
-    descriptor = validate_descriptor(yaml.load(open(descriptor, "r")))
+def load_descriptor(descriptor_path, path_list=[]):
+    descriptor = validate_descriptor(yaml.load(open(descriptor_path, "r")))
     if path_list:
         return subdescriptor(descriptor, path_list)
     return descriptor

--- a/ubr/file_target.py
+++ b/ubr/file_target.py
@@ -1,8 +1,7 @@
 import os, shutil, glob2
 from ubr import utils
-
-import logging
-logger = logging.getLogger(__name__)
+from conf import logging
+LOG = logging.getLogger(__name__)
 
 def copy_file(src, dest):
     "a wrapper around shutil.copyfile that will create the dest dirs if necessary"
@@ -36,13 +35,13 @@ def wrangle_files(path_list):
         missing = filter(lambda p: '*' not in p, set(path_list) - set(new_path_list))
         if missing:
             msg = "the following files failed validation and were removed from this backup: %s"
-            logger.error(msg, ", ".join(missing))
+            LOG.error(msg, ", ".join(missing))
     return new_path_list
 
 def backup(path_list, destination):
     """embarassingly simple 'copy each of the files specified
     to new destination, ignoring the common parents'"""
-    logger.debug('given paths %s with destination %s', path_list, destination)
+    LOG.debug('given paths %s with destination %s', path_list, destination)
 
     new_path_list = wrangle_files(path_list)
     utils.mkdir_p(destination)
@@ -58,7 +57,7 @@ def backup(path_list, destination):
 
 
 def _restore(path, backup_dir):
-    logger.debug("received path %s and input dir %s", path, backup_dir)
+    LOG.debug("received path %s and input dir %s", path, backup_dir)
     data = {
         'backup_src': os.path.join(backup_dir, path.lstrip('/')),
         'broken_dest': path}

--- a/ubr/main.py
+++ b/ubr/main.py
@@ -3,7 +3,7 @@ import os, sys
 import logging
 from ubr import conf, utils, s3, mysql_target, file_target, tgz_target
 from ubr.descriptions import load_descriptor, find_descriptors, pname
-from ubr.conf import CONFIG_DIR, RESTORE_DIR, BUCKET
+from ubr.conf import RESTORE_DIR, BUCKET
 
 LOG = logging.getLogger(__name__)
 _handler = logging.FileHandler('ubr.log')
@@ -48,21 +48,21 @@ def restore(descriptor, backup_dir):
 #
 #
 
-def file_backup(config_dir=CONFIG_DIR, hostname=utils.hostname(), path_list=None):
-    return [backup(load_descriptor(descriptor, path_list)) for descriptor in find_descriptors(config_dir)]
+def file_backup(hostname=utils.hostname(), path_list=None):
+    return [backup(load_descriptor(descriptor, path_list)) for descriptor in find_descriptors(conf.CONFIG_DIR)]
 
-def file_restore(config_dir=CONFIG_DIR, hostname=utils.hostname(), path_list=None):
+def file_restore(hostname=utils.hostname(), path_list=None):
     "restore backups from local files using descriptors"
     def _do(descriptor):
         restore_dir = os.path.join(RESTORE_DIR, pname(descriptor), hostname)
         return restore(load_descriptor(descriptor, path_list), restore_dir)
-    return map(_do, find_descriptors(config_dir))
+    return map(_do, find_descriptors(conf.CONFIG_DIR))
 
-def s3_backup(config_dir=CONFIG_DIR, hostname=None, path_list=None):
+def s3_backup(hostname=None, path_list=None):
     "create backups using descriptors and then upload to s3"
     # hostname is ignored (for now? remote backups in future??)
     LOG.info("backing up ...")
-    for descriptor in find_descriptors(config_dir):
+    for descriptor in find_descriptors(conf.CONFIG_DIR):
         project = pname(descriptor)
         if not project:
             LOG.warning("no project name, skipping given descriptor %r", descriptor)
@@ -70,13 +70,13 @@ def s3_backup(config_dir=CONFIG_DIR, hostname=None, path_list=None):
         backup_results = backup(load_descriptor(descriptor, path_list))
         s3.upload_backup(BUCKET, backup_results, project, utils.hostname())
 
-def s3_restore(config_dir=CONFIG_DIR, hostname=utils.hostname(), path_list=None):
+def s3_download(hostname=utils.hostname(), path_list=None):
     """by specifying a different hostname, you can download a backup
     from a different machine. Of course you will need that other
     machine's descriptor in /etc/ubr/ ... otherwise it won't know
     what to download and where to restore"""
     LOG.info("restoring ...")
-    for descriptor in find_descriptors(config_dir):
+    for descriptor in find_descriptors(conf.CONFIG_DIR):
         project = pname(descriptor)
         if not project:
             LOG.warning("no project name, skipping given descriptor %r", descriptor)
@@ -89,13 +89,23 @@ def s3_restore(config_dir=CONFIG_DIR, hostname=utils.hostname(), path_list=None)
         utils.mkdir_p(download_dir)
 
         # FIX: ... why do I have to download individually when I can upload all at once?
+        results = []
         for target, path_list in descriptor.items():
             s3.download_latest_backup(download_dir, \
                                       BUCKET, \
                                       project, \
                                       hostname, \
                                       target)
+        results.append((descriptor, download_dir))
 
+    return results
+
+def s3_restore(hostname=utils.hostname(), path_list=None):
+    "same as the download action, but then restores the files/databases/whatever to where they came from"
+    # download everything first ...
+    results = s3_download(hostname, path_list)
+    # ... then restore
+    for descriptor, download_dir in results:
         restore(descriptor, download_dir)
 
 #
@@ -105,19 +115,21 @@ def s3_restore(config_dir=CONFIG_DIR, hostname=utils.hostname(), path_list=None)
 def parseargs(args):
     "accepts a list of arguments and returns a list of validated ones"
     parser = argparse.ArgumentParser()
-    parser.add_argument('config', help='path to a directory where I can find *-backup.yaml files (descriptors)')
-    parser.add_argument('action', nargs='?', default='backup', choices=['backup', 'restore'], help='am I backing things up or restoring them?')
+    parser.add_argument('action', nargs='?', default='backup', choices=['backup', 'restore', 'download'], help='am I backing things up or restoring them?')
     parser.add_argument('location', nargs='?', default='s3', choices=['s3', 'file'], help='am I doing this action from the file system or from S3?')
     parser.add_argument('hostname', nargs='?', default=utils.hostname(), help='if restoring files, should I restore the backup of another host? good for restoring production backups to a different environment')
 
-    # some overlap with the `config` arg: config specifies the set of targets, paths specify which ones.
     parser.add_argument('paths', nargs='*', default=[], help='dot-delimited paths to backup/restore only specific targets. for example: mysql-database.mydb1')
 
     args = parser.parse_args(args)
-    return [getattr(args, key, None) for key in ['config', 'action', 'location', 'hostname', 'paths']]
+
+    if args.action == 'download' and args.location == 'file':
+        parser.error("use 's3' for location when downloading")
+
+    return [getattr(args, key, None) for key in ['action', 'location', 'hostname', 'paths']]
 
 def main(args):
-    config, action, fromloc, hostname, paths = parseargs(args)
+    action, fromloc, hostname, paths = parseargs(args)
     decision_tree = {
         'backup': {
             's3': s3_backup,
@@ -127,10 +139,12 @@ def main(args):
             's3': s3_restore,
             'file': file_restore,
         },
+        'download': {
+            's3': s3_download,
+        }
     }
-    # x[backup][file](**{'config_dir': ..., 'hostname': 'localhost'})
+    # x[backup][file](**{'hostname': 'localhost'})
     return decision_tree[action][fromloc](**{
-        'config_dir': config,
         'hostname': hostname,
         'path_list': paths,
     })

--- a/ubr/mysql_target.py
+++ b/ubr/mysql_target.py
@@ -4,7 +4,7 @@ from ubr.utils import ensure
 import pymysql.cursors
 import logging
 
-logger = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
 
 def defaults(db=None, **overrides):
     "default mysql args"
@@ -63,7 +63,7 @@ def create(db, **kwargs):
     return 0 == mysql_cli_cmd('create database if not exists %s;' % db, **kwargs)
 
 def load(db, dump_path, dropdb=False, **kwargs):
-    logger.info("loading dump %r into db %r. dropdb=%s", dump_path, db, dropdb)
+    LOG.info("loading dump %r into db %r. dropdb=%s", dump_path, db, dropdb)
     args = defaults(db, path=dump_path, **kwargs)
     if dropdb:
         # reset the database before loading the fixture
@@ -72,10 +72,10 @@ def load(db, dump_path, dropdb=False, **kwargs):
                     not dbexists(db), \
                     create(db, **kwargs), \
                     dbexists(db)]), msg
-        logger.info("passed assertion check!")
+        LOG.info("passed assertion check!")
     cmd = "mysql -u %(user)s -p%(pass)s -h %(host)s -P %(port)s %(dbname)s < %(path)s" % args
     if dump_path.endswith('.gz'):
-        logger.info("dealing with a gzipped file")
+        LOG.info("dealing with a gzipped file")
         cmd = "zcat %(path)s | mysql -u %(user)s -p%(pass)s -h %(host)s -P %(port)s --database %(dbname)s" % args
     return 0 == utils.system(cmd)
 
@@ -121,7 +121,8 @@ def _restore(db, backup_dir):
         assert os.path.isfile(dump_path), "expected path %r does not exist or is not a file." % dump_path
         return (db, load(db, dump_path, dropdb=True))
     except Exception:
-        logger.exception("unhandled unexception attempting to restore database %r", db)
+        LOG.exception("unhandled unexception attempting to restore database %r", db)
+        #raise # this is what we should be doing
         return (db, False)
 
 def restore(db_list, backup_dir):

--- a/ubr/s3.py
+++ b/ubr/s3.py
@@ -243,7 +243,6 @@ def latest_backups(bucket, project, hostname, target, path=None):
     # there may have been multiple backups
     # figure out the distinct files and return the latest of each
     backup_list = backups(bucket, project, hostname, target, path)
-    print 'got backups',backup_list
     mmap = {}
     for path in backup_list:
         # path ll: u'-test/201701/20170112_testmachine_164429-archive-2a4c0db0.tar.gz'

--- a/ubr/tests/test_main.py
+++ b/ubr/tests/test_main.py
@@ -4,49 +4,76 @@ from base import BaseCase
 
 class Main(BaseCase):
     def setUp(self):
-        mock.patch('ubr.utils.hostname', return_value='test-machine').start()
+        self.patcher = mock.patch('ubr.utils.hostname', return_value='test-machine')
+        self.patcher.start()
 
     def tearDown(self):
-        pass
+        self.patcher.stop()
 
     def test_parseargs_minimal_args(self):
-        given = ['/etc/ubr/foo-backup.yaml']
-        expected = ['/etc/ubr/foo-backup.yaml', 'backup', 's3', 'test-machine', []]
+        given = []
+        expected = ['backup', 's3', 'test-machine', []]
         self.assertEqual(main.parseargs(given), expected)
 
     def test_parseargs_two_args(self):
-        given = ['/etc/ubr/foo-backup.yaml', 'restore']
-        expected = ['/etc/ubr/foo-backup.yaml', 'restore', 's3', 'test-machine', []]
+        given = ['restore']
+        expected = ['restore', 's3', 'test-machine', []]
         self.assertEqual(main.parseargs(given), expected)
 
     def test_parseargs_three_args(self):
-        given = ['/etc/ubr/foo-backup.yaml', 'restore', 'file']
-        expected = ['/etc/ubr/foo-backup.yaml', 'restore', 'file', 'test-machine', []]
+        given = ['restore', 'file']
+        expected = ['restore', 'file', 'test-machine', []]
         self.assertEqual(main.parseargs(given), expected)
 
     def test_parseargs_four_args(self):
-        given = ['/etc/ubr/foo-backup.yaml', 'restore', 'file', 'example.org']
-        expected = ['/etc/ubr/foo-backup.yaml', 'restore', 'file', 'example.org', []]
+        given = ['restore', 'file', 'example.org']
+        expected = ['restore', 'file', 'example.org', []]
         self.assertEqual(main.parseargs(given), expected)
 
     def test_parseargs_five_args(self):
         "optional fifth+ args to specify targets within the descriptor"
-        given = ['/etc/ubr/foo-backup.yaml', 'restore', 'file', 'example.org', 'mysql-database.mydb1']
-        expected = ['/etc/ubr/foo-backup.yaml', 'restore', 'file', 'example.org', ['mysql-database.mydb1']]
+        given = ['restore', 'file', 'example.org', 'mysql-database.mydb1']
+        expected = ['restore', 'file', 'example.org', ['mysql-database.mydb1']]
         self.assertEqual(main.parseargs(given), expected)
 
     def test_parseargs_five_plus_args(self):
         "optional fifth+ args to specify targets within the descriptor"
-        given = ['/etc/ubr/foo-backup.yaml', 'restore', 'file', 'example.org']
+        given = ['restore', 'file', 'example.org']
         given += [
             'mysql-database.mydb1',
             'files./opt/thing/',
             'mysql-database.mydb2'
         ]
-        expected = ['/etc/ubr/foo-backup.yaml', 'restore', 'file', 'example.org']
+        expected = ['restore', 'file', 'example.org']
         expected += [[
             'mysql-database.mydb1',
             'files./opt/thing/',
             'mysql-database.mydb2',
         ]]
         self.assertEqual(main.parseargs(given), expected)
+
+    def test_download_args(self):
+        cases = [
+            # download most recent files for this machine from s3
+            (['download'], ['download', 's3', 'test-machine', []]),
+
+            # same again
+            (['download', 's3'], ['download', 's3', 'test-machine', []]),
+
+            # download most recent files from the prod machine from s3
+            (['download', 's3', 'prod--test-machine'], ['download', 's3', 'prod--test-machine', []]),
+
+            # download just the mysql database 'thing' from the prod machine from s3
+            (['download', 's3', 'prod--test-machine', 'mysql-database.thing'], ['download', 's3', 'prod--test-machine', ['mysql-database.thing']]),
+        ]
+        for given, expected in cases:
+            actual = main.parseargs(given)
+            self.assertEqual(actual, expected, "given %r I expected %r but got %r" % (given, expected, actual))
+
+    def test_download_bad_args(self):
+        bad_cases = [
+            # downloading a file from filesystem? 
+            (['download', 'file'], ['download', 'file', 'test-machine', []]),
+        ]
+        for given, expected in bad_cases:
+            self.assertRaises(SystemExit, main.parseargs, given)


### PR DESCRIPTION
* removes the first arg to the ubr.py script (location of config dir)
* adds a 'download' command that simply downloads the files without restoring them
* fixed a bug when using paths + multiple descriptors
* fixed a bug where partial restores were not being done