### PR TITLE
Feature: added ability to specify the 'working directory'

### DIFF
--- a/elife.cfg
+++ b/elife.cfg
@@ -1,3 +1,6 @@
+[general]
+working_dir=/tmp/
+
 [mysql]
 user=root
 pass=root

--- a/ubr/conf.py
+++ b/ubr/conf.py
@@ -4,6 +4,10 @@ import logging
 from pythonjsonlogger import jsonlogger
 # from ubr import utils # DONT!
 
+#
+# logging
+#
+
 ROOTLOG = logging.getLogger("")
 _supported_keys = [
     #'asctime',
@@ -41,10 +45,9 @@ ROOTLOG.setLevel(logging.DEBUG)
 import boto3
 boto3.set_stream_logger('', logging.CRITICAL)
 
-BUCKET = 'elife-app-backups'
-CONFIG_DIR = '/etc/ubr/'
-
-RESTORE_DIR = '/tmp/ubr/' # which dir to download files to and restore from
+#
+# utils
+#
 
 # duplicated from utils
 def mkdir_p(path):
@@ -58,8 +61,11 @@ def mkdir_p(path):
             ROOTLOG.error("problem attempting to create path %s: %s", path, err)
             raise
 
+#
+# config parsing
+#
 
-PROJECT_DIR = os.getcwdu() # ll: /path/to/adaptor/
+PROJECT_DIR = os.getcwdu() # ll: /path/to/ubr/
 
 CFG_NAME = 'app.cfg'
 DYNCONFIG = configparser.SafeConfigParser(**{
@@ -81,8 +87,20 @@ def cfg(path, default=0xDEADBEEF):
     except Exception:
         raise
 
+#
+# config
+#
 
-mkdir_p(RESTORE_DIR)
+# which S3 bucket should ubr upload backups to/restore backups from?
+BUCKET = 'elife-app-backups'
+
+# where should ubr look for backup descriptions?
+DESCRIPTOR_DIR = '/etc/ubr/'
+
+# where should ubr do it's work? /tmp/ubr/ by default
+WORKING_DIR = join(cfg('general.working_dir', '/tmp'), 'ubr')
+
+mkdir_p(WORKING_DIR)
 
 # we used to pick these up from wherever boto could find them
 # now a machine may have several sets of credentials for different tasks

--- a/ubr/s3.py
+++ b/ubr/s3.py
@@ -9,7 +9,7 @@ from ubr.utils import ensure
 
 LOG = logging.getLogger(__name__)
 
-def remove_targets(path_list, rooted_at="/tmp/"):
+def remove_targets(path_list, rooted_at=conf.WORKING_DIR):
     "deletes the list of given paths if the path starts with the given root (default /tmp/)."
     return map(os.unlink, filter(lambda p: p.startswith(rooted_at), filter(os.path.isfile, path_list)))
 

--- a/ubr/tgz_target.py
+++ b/ubr/tgz_target.py
@@ -1,5 +1,5 @@
 import os, tarfile
-from ubr import utils, file_target
+from ubr import utils, file_target, conf
 from conf import logging
 import hashlib
 from ubr.utils import ensure
@@ -7,7 +7,7 @@ from ubr.utils import ensure
 LOG = logging.getLogger(__name__)
 LOG.level = logging.DEBUG
 
-TMP_SUBDIR = '.tgz-tmp'
+TMP_SUBDIR = '.tgz-tmp' # this smells
 
 def filename_for_paths(path_list):
     "given a list of filenames, return a predictable string that can be used as a filename"
@@ -64,7 +64,7 @@ def backup(path_list, destination):
     # dictated by the kernal. in directories with lots of files, this length is exceeded
     # quickly and returns a mysterious 32517 (or 127 mod 8) return code, which is documented
     # as 'command not found', which *is not* the case at all.
-    manifest_path = '/tmp/ubr.manifest'
+    manifest_path = os.path.join(conf.WORKING_DIR, 'ubr.manifest')
     open(manifest_path, 'w').write("\n".join(expanded_path_list))
 
     # now when we create the archive file, we tell it to pull the paths from the manifest


### PR DESCRIPTION
* this is where ubr will do it's work. default is `/tmp`. replaces RESTORE_DIR. 
* renamed CONFIG_DIR to DESCRIPTOR_DIR as the `/etc/ubr/config` file is no longer used