### PR TITLE
bugfix: piping output to gzip hid mysql error

### DIFF
--- a/ubr/s3.py
+++ b/ubr/s3.py
@@ -232,6 +232,7 @@ def backups(bucket, project, hostname, target, path=None):
     # we have potentially many files at this point
     # we only want to download the latest ones
 
+    # BUG HERE
     if path:
         # a specific file is wanted, easy
         backups = [backups[-1]]

--- a/ubr/tests/test_mysql_target.py
+++ b/ubr/tests/test_mysql_target.py
@@ -27,7 +27,8 @@ class TestDatabaseBackup(BaseCase):
         self.assertTrue(os.path.isfile(expected_path))
 
     def test_dump_db_fails_if_db_not_found(self):
-        pass
+        descriptor = {'mysql-database': ['pants-party']}
+        self.assertRaises(OSError, main.backup, descriptor)
 
 
 class TestDatabaseRestore(BaseCase):

--- a/ubr/utils.py
+++ b/ubr/utils.py
@@ -1,4 +1,4 @@
-import os
+import os, subprocess
 from datetime import datetime
 import errno
 from itertools import takewhile, izip
@@ -21,11 +21,24 @@ def ensure(assertion, msg, ExceptionClass=AssertionError):
     if not assertion:
         raise ExceptionClass(msg)
 
-def system(cmd):
+
+def system1(cmd):
     LOG.info(cmd)
     retval = os.system(cmd)
     LOG.info("return status %s", retval)
     return retval
+
+def system2(cmd):
+    args = ['/bin/bash', '-c', cmd]
+    process = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    stdout, stderr = process.communicate()
+    # return process.returncode, stdout
+    LOG.info(stdout)
+    LOG.warn(stderr)
+    return process.returncode
+
+
+system = system2
 
 def mkdir_p(path):
     try:


### PR DESCRIPTION
fixes two issues:
* piping dump output to gzip hid mysql error if database was missing or inaccessible
* the `--databases` flag was adding header statements to the dumps to *create* the database and then *use* it. this having bit me during the recent civi migration. 

also took opportunity to make the mysql commands a little clearer