### PR TITLE
Fail on not supported command, wire up missing psql load

### DIFF
--- a/ubr/main.py
+++ b/ubr/main.py
@@ -151,7 +151,9 @@ def adhoc_file_restore(path_list):
         if target == 'mysql-database':
             mysql_target.load(path, source_file, dropdb=True)
         else:
-            LOG.warning("only adhoc mysql file restores are currently handled.")
+            message = "only adhoc mysql file restores are currently handled, not `%s`"
+            LOG.error(message, target)
+            raise RuntimeError(message % target)
 
 #
 # bootstrap

--- a/ubr/main.py
+++ b/ubr/main.py
@@ -153,7 +153,7 @@ def adhoc_file_restore(path_list):
         elif target == 'postgresql-database':
             psql_target.load(path, source_file, dropdb=True)
         else:
-            message = "only adhoc mysql file restores are currently handled, not `%s`"
+            message = "only adhoc database restores are currently handled, not `%s`"
             LOG.error(message, target)
             raise RuntimeError(message % target)
 

--- a/ubr/main.py
+++ b/ubr/main.py
@@ -150,6 +150,8 @@ def adhoc_file_restore(path_list):
 
         if target == 'mysql-database':
             mysql_target.load(path, source_file, dropdb=True)
+        elif target == 'postgresql-database':
+            psql_target.load(path, source_file, dropdb=True)
         else:
             message = "only adhoc mysql file restores are currently handled, not `%s`"
             LOG.error(message, target)

--- a/ubr/psql_target.py
+++ b/ubr/psql_target.py
@@ -49,9 +49,17 @@ def drop(dbname):
     kwargs = defaults(dbname)
     return os.system(cmd % kwargs) == 0
 
-def load(dbname, path_to_dump):
+def load(dbname, path_to_dump, dropdb=False):
     # https://www.postgresql.org/docs/8.1/static/backup.html#BACKUP-DUMP-RESTORE
     ensure(os.path.exists(path_to_dump), "no such path: %r" % path_to_dump)
+
+    if dropdb:
+        msg = "failed to drop+create the database prior to loading fixture."
+        assert all([drop(dbname),
+                    not dbexists(dbname),
+                    create(dbname),
+                    dbexists(dbname)]), msg
+
     cmd = """cat %(path_to_dump)s | gunzip | psql \
     --username %(user)s \
     --no-password \

--- a/ubr/tests/test_psql_target.py
+++ b/ubr/tests/test_psql_target.py
@@ -123,10 +123,23 @@ class Restore(BaseCase):
         psql.create(self.db)
         fixture = join(self.fixture_dir, 'psql_ubr_testdb.psql.gz')
         psql.load(self.db, fixture)
-        psql.runsql(self.db, "delete from table1")
-        self.assertEqual(0, len(list(psql.runsql(self.db, "select * from table1"))))
-
-        # we've modified the existing database
+        self._empty_db()
 
         psql.restore([self.db], self.fixture_dir)
         self.assertEqual(2, len(list(psql.runsql(self.db, "select * from table1"))))
+
+    def test_load_can_drop_the_existing_db(self):
+        "restoring a database drops any existing one"
+        psql.create(self.db)
+        fixture = join(self.fixture_dir, 'psql_ubr_testdb.psql.gz')
+        psql.load(self.db, fixture)
+        self._empty_db()
+
+        psql.load(self.db, fixture, dropdb=True)
+        self.assertEqual(2, len(list(psql.runsql(self.db, "select * from table1"))))
+
+    def _empty_db(self):
+        psql.runsql(self.db, "delete from table1")
+        self.assertEqual(0, len(list(psql.runsql(self.db, "select * from table1"))))
+        # we've modified the existing database
+

--- a/ubr/tests/test_psql_target.py
+++ b/ubr/tests/test_psql_target.py
@@ -123,7 +123,9 @@ class Restore(BaseCase):
         psql.create(self.db)
         fixture = join(self.fixture_dir, 'psql_ubr_testdb.psql.gz')
         psql.load(self.db, fixture)
-        self._empty_db()
+
+        psql.runsql(self.db, "delete from table1")
+        self.assertEqual(0, len(list(psql.runsql(self.db, "select * from table1"))))
 
         psql.restore([self.db], self.fixture_dir)
         self.assertEqual(2, len(list(psql.runsql(self.db, "select * from table1"))))
@@ -133,13 +135,9 @@ class Restore(BaseCase):
         psql.create(self.db)
         fixture = join(self.fixture_dir, 'psql_ubr_testdb.psql.gz')
         psql.load(self.db, fixture)
-        self._empty_db()
+
+        psql.runsql(self.db, "delete from table1")
+        self.assertEqual(0, len(list(psql.runsql(self.db, "select * from table1"))))
 
         psql.load(self.db, fixture, dropdb=True)
         self.assertEqual(2, len(list(psql.runsql(self.db, "select * from table1"))))
-
-    def _empty_db(self):
-        psql.runsql(self.db, "delete from table1")
-        self.assertEqual(0, len(list(psql.runsql(self.db, "select * from table1"))))
-        # we've modified the existing database
-


### PR DESCRIPTION
I tried setting up a restore for lax--end2end's PostgreSQL database, the salt highstate silently passed but nothing was restored. Safer to fail the build.

Also, it seems possible to wire up the missing case to make it work.