### PR TITLE
Bugfix: psql restores

### DIFF
--- a/ubr/conf.py
+++ b/ubr/conf.py
@@ -48,7 +48,7 @@ ROOTLOG.setLevel(logging.DEBUG)
 
 # tell boto to pipe down
 loggers = ['boto3', 'botocore', 's3transfer']
-[logging.getLogger(nom).setLevel(logging.CRITICAL) for nom in loggers]
+[logging.getLogger(nom).setLevel(logging.ERROR) for nom in loggers]
 
 #
 # utils

--- a/ubr/conf.py
+++ b/ubr/conf.py
@@ -1,3 +1,4 @@
+import boto3
 import os, configparser
 from os.path import join
 import logging
@@ -42,8 +43,8 @@ ROOTLOG.addHandler(_handler)
 ROOTLOG.setLevel(logging.DEBUG)
 
 # tell boto to pipe down
-import boto3
-boto3.set_stream_logger('', logging.CRITICAL)
+loggers = ['boto3', 'botocore', 's3transfer']
+[logger.getLogger(nom).setLevel(logging.CRITICAL) for nom in loggers]
 
 #
 # utils

--- a/ubr/conf.py
+++ b/ubr/conf.py
@@ -38,7 +38,12 @@ _handler = logging.StreamHandler()
 _handler.setLevel(logging.DEBUG)
 _handler.setFormatter(logging.Formatter('%(levelname)s - %(asctime)s - %(message)s'))
 
+_filehandler = logging.FileHandler('ubr.log')
+_filehandler.setFormatter(_formatter)
+_filehandler.setLevel(logging.INFO)
+
 ROOTLOG.addHandler(_handler)
+ROOTLOG.addHandler(_filehandler)
 ROOTLOG.setLevel(logging.DEBUG)
 
 # tell boto to pipe down

--- a/ubr/conf.py
+++ b/ubr/conf.py
@@ -1,4 +1,3 @@
-import boto3
 import os, configparser
 from os.path import join
 import logging
@@ -44,7 +43,7 @@ ROOTLOG.setLevel(logging.DEBUG)
 
 # tell boto to pipe down
 loggers = ['boto3', 'botocore', 's3transfer']
-[logger.getLogger(nom).setLevel(logging.CRITICAL) for nom in loggers]
+[logging.getLogger(nom).setLevel(logging.CRITICAL) for nom in loggers]
 
 #
 # utils

--- a/ubr/file_target.py
+++ b/ubr/file_target.py
@@ -38,7 +38,7 @@ def wrangle_files(path_list):
             LOG.error(msg, ", ".join(missing))
     return new_path_list
 
-def backup(path_list, destination):
+def backup(path_list, destination, prompt=False):
     """embarassingly simple 'copy each of the files specified
     to new destination, ignoring the common parents'"""
     LOG.debug('given paths %s with destination %s', path_list, destination)
@@ -64,7 +64,7 @@ def _restore(path, backup_dir):
     retcode = utils.system(cmd)
     return (path, retcode == 0)
 
-def restore(path_list, backup_dir):
+def restore(path_list, backup_dir, prompt=False):
     """how do we restore files? we rsync the target from the input dir.
 
     the 'backup_dir' is the dir we read backups from with the given path_list providing further path information

--- a/ubr/main.py
+++ b/ubr/main.py
@@ -137,6 +137,7 @@ def restore_from_s3(hostname=utils.hostname(), path_list=None):
     "same as the download action, but then restores the files/databases/whatever to where they came from"
     # download everything first ...
     results = download_from_s3(hostname, path_list)
+    # ll: [({'postgresql-database': ['laxbackfilltest']}, u'/tmp/ubr/lax/prod--lax.elifesciences.org')]
     # ... then restore
     return [restore(descriptor, download_dir) for descriptor, download_dir in results]
 
@@ -181,6 +182,9 @@ def parseargs(args):
     parser.add_argument('location', nargs='?', default='s3', choices=['s3', 'file'], help='am I doing this action from the file system or from S3?')
     parser.add_argument('hostname', nargs='?', default=utils.hostname(), help='if restoring files, should I restore the backup of another host? good for restoring production backups to a different environment')
     parser.add_argument('paths', nargs='*', default=[], help='dot-delimited paths to backup/restore only specific targets. for example: mysql-database.mydb1')
+
+    # should a prompt be issued when necessary?
+    #parser.add_argument('--prompt', nargs='?', action='store_true', default=False)
 
     args = parser.parse_args(args)
 

--- a/ubr/main.py
+++ b/ubr/main.py
@@ -27,6 +27,12 @@ def dofortarget(target, fnom, *args, **kwargs):
         raise EnvironmentError("module %r (%s) has no function %r" % (mod, target, fnom))
     return fn(*args, **kwargs)
 
+def machinedir(hostname, descriptor_path):
+    "returns a path where this machine can deal with this descriptor"
+    # ll: /tmp/ubr/civicrm/crm--prod/
+    # ll: /tmp/ubr/lax/lax--ci/
+    return os.path.join(conf.WORKING_DIR, pname(descriptor_path), hostname)
+
 #
 #
 #
@@ -48,12 +54,6 @@ def restore(descriptor, backup_dir):
 #
 #
 #
-
-def machinedir(hostname, descriptor_path):
-    "returns a path where this machine can deal with this descriptor"
-    # ll: /tmp/ubr/civicrm/crm--prod/
-    # ll: /tmp/ubr/lax/lax--ci/
-    return os.path.join(conf.WORKING_DIR, pname(descriptor_path), hostname)
 
 def backup_to_file(hostname, path_list=None):
     results = []
@@ -109,7 +109,7 @@ def download_from_s3(hostname=utils.hostname(), path_list=None):
                     project,
                     hostname,
                     target,
-                    backup_name(target, path)))
+                    path))
 
         results.append((descriptor, download_dir))
 
@@ -132,7 +132,7 @@ def adhoc_s3_download(path_list):
         try:
             # being adhoc, we can't manage a machinename() call
             download_dir = join(conf.WORKING_DIR, os.path.basename(remote_path))
-            return s3.download_from_s3(conf.BUCKET, remote_path, download_dir)
+            return s3.download(conf.BUCKET, remote_path, download_dir)
         except AssertionError as err:
             LOG.warning(err)
     return map(download, path_list)

--- a/ubr/mysql_target.py
+++ b/ubr/mysql_target.py
@@ -104,12 +104,12 @@ def load(db, dump_path, dropdb=False, **kwargs):
 
     return utils.system(cmd) == 0
 
-def dumpname(db):
+def backup_name(db):
     "generates a filename for the given db"
     return db + "-mysql.gz" # looks like: ELIFECIVICRM-mysql.gz  or  /foo/bar/db-mysql.gz
 
 def dump(db, output_path, **kwargs):
-    output_path = dumpname(output_path)
+    output_path = backup_name(output_path)
     args = defaults(db, path=output_path, **kwargs)
     # --skip-dump-date # suppresses the 'Dump completed on <YMD HMS>'
     # at the bottom of each dump file, defeating duplicate checking
@@ -152,7 +152,7 @@ def backup(path_list, destination):
 
 def _restore(db, backup_dir):
     try:
-        dump_path = os.path.join(backup_dir, dumpname(db))
+        dump_path = os.path.join(backup_dir, backup_name(db))
         assert os.path.isfile(dump_path), "expected path %r does not exist or is not a file." % dump_path
         return (db, load(db, dump_path, dropdb=True))
     except Exception:

--- a/ubr/mysql_target.py
+++ b/ubr/mysql_target.py
@@ -139,7 +139,7 @@ def _backup(path, destination):
     output_path = os.path.join(destination, path)
     return dump(path, output_path)
 
-def backup(path_list, destination):
+def backup(path_list, destination, prompt=False):
     "dumps a list of databases and database tables"
     retval = utils.system("mkdir -p %s" % destination)
     if not retval == 0:
@@ -160,7 +160,7 @@ def _restore(db, backup_dir):
         # raise # this is what we should be doing
         return (db, False)
 
-def restore(db_list, backup_dir):
+def restore(db_list, backup_dir, prompt=False):
     return {
         'output': map(lambda db: _restore(db, backup_dir), db_list)
     }

--- a/ubr/psql_target.py
+++ b/ubr/psql_target.py
@@ -174,7 +174,7 @@ def backup_missing_prompt_user(dbname, dump_path):
         # nothing else can be restored, return what we were given
         return dump_path
     # opportunity!
-    other_files = map(lambda fname: join(dump_path, fname), other_files) # full paths
+    other_files = map(lambda fname: join(backup_dir, fname), other_files) # full paths
     print "expected file missing: %s" % dump_path
     print "other files are available to restore over %s" % dbname
     return utils.choose('choose: ', other_files, os.path.basename)
@@ -193,7 +193,7 @@ def _restore(dbname, backup_dir, prompt=False):
         # raise # this is what we should be doing
         return (dbname, False)
 
-def restore(path_list, backup_dir):
+def restore(path_list, backup_dir, prompt=False):
     return {
-        'output': [_restore(db, backup_dir) for db in path_list]
+        'output': [_restore(db, backup_dir, prompt) for db in path_list]
     }

--- a/ubr/psql_target.py
+++ b/ubr/psql_target.py
@@ -179,7 +179,7 @@ def backup_missing_prompt_user(dbname, dump_path):
     print "other files are available to restore over %s" % dbname
     return utils.choose('choose: ', other_files, os.path.basename)
 
-def _restore(dbname, backup_dir, prompt=False):
+def _restore(dbname, backup_dir, prompt=True):
     "look for a backup of $dbname in $backup_dir and restore it"
     try:
         backup_dir = backup_dir or conf.WORKING_DIR
@@ -193,7 +193,7 @@ def _restore(dbname, backup_dir, prompt=False):
         # raise # this is what we should be doing
         return (dbname, False)
 
-def restore(path_list, backup_dir, prompt=False):
+def restore(path_list, backup_dir, prompt=True):
     return {
         'output': [_restore(db, backup_dir, prompt) for db in path_list]
     }

--- a/ubr/psql_target.py
+++ b/ubr/psql_target.py
@@ -166,11 +166,26 @@ def backup(path_list, destination=None):
         'output': [_backup(dbname, destination) for dbname in path_list if dbexists(dbname)]
     }
 
-def _restore(dbname, backup_dir):
+def backup_missing_prompt_user(dbname, dump_path):
+    "in cases where we can't find the file to backup, there may be another file we can restore from that has been downloaded. prompt the user for the file"
+    backup_dir = os.path.dirname(dump_path)
+    other_files = os.listdir(backup_dir)
+    if not other_files:
+        # nothing else can be restored, return what we were given
+        return dump_path
+    # opportunity!
+    other_files = map(lambda fname: join(dump_path, fname), other_files) # full paths
+    print "expected file missing: %s" % dump_path
+    print "other files are available to restore over %s" % dbname
+    return utils.choose('choose: ', other_files, os.path.basename)
+
+def _restore(dbname, backup_dir, prompt=False):
     "look for a backup of $dbname in $backup_dir and restore it"
     try:
         backup_dir = backup_dir or conf.WORKING_DIR
         dump_path = join(backup_dir, backup_name(dbname))
+        if prompt and not os.path.exists(dump_path):
+            dump_path = backup_missing_prompt_user(dbname, dump_path)
         ensure(os.path.exists(dump_path), "expected path %r does not exist or is not a file." % dump_path)
         return (dbname, all([drop_if_exists(dbname), create(dbname), load(dbname, dump_path)]))
     except Exception:

--- a/ubr/psql_target.py
+++ b/ubr/psql_target.py
@@ -155,7 +155,7 @@ def _backup(dbname, destination):
     ensure(dump(dbname, output_path), "postgresql database %r backup failed" % dbname)
     return output_path
 
-def backup(path_list, destination=None):
+def backup(path_list, destination=None, prompt=False):
     destination = destination or conf.WORKING_DIR
     destination = os.path.abspath(destination)
     utils.system("mkdir -p %s" % destination)
@@ -179,7 +179,7 @@ def backup_missing_prompt_user(dbname, dump_path):
     print "other files are available to restore over %s" % dbname
     return utils.choose('choose: ', other_files, os.path.basename)
 
-def _restore(dbname, backup_dir, prompt=True):
+def _restore(dbname, backup_dir, prompt):
     "look for a backup of $dbname in $backup_dir and restore it"
     try:
         backup_dir = backup_dir or conf.WORKING_DIR

--- a/ubr/s3.py
+++ b/ubr/s3.py
@@ -105,6 +105,7 @@ def filter_listing(file_list, project, host, target=None, filename=''):
         lu = {
             'tar-gzipped': 'archive-.+\.tar\.gz',
             'mysql-database': '.+\-mysql\.gz',
+            'postgresql-database': '.+\-psql.gz',
         }
         filename = lu[target]
     regex = r"%(project)s/(?P<ym>\d+)/(?P<ymd>\d+)_%(host)s_(?P<hms>\d+)\-%(filename)s" % locals()
@@ -250,7 +251,7 @@ def backups(bucket, project, hostname, target, path=None):
 def latest_backups(bucket, project, hostname, target, path=None):
     # there may have been multiple backups
     # figure out the distinct files and return the latest of each
-    backup_list = backups(bucket, project, hostname, target, path)
+    backup_list = backups(bucket, project, hostname, target) #, path) # 'path' here is the descriptor path, not the filename
     if not backup_list:
         return []
 

--- a/ubr/s3.py
+++ b/ubr/s3.py
@@ -215,6 +215,7 @@ def download(bucket, remote_src, local_dest):
     inst = DownloadProgressPercentage("s3://%(bucket)s/%(remote_src)s" % locals())
     utils.mkdir_p(os.path.dirname(local_dest))
     s3_conn().download_file(bucket, remote_src, local_dest, Callback=inst)
+    return local_dest
 
 
 def backups(bucket, project, hostname, target, path=None):
@@ -292,7 +293,6 @@ def download_latest_backup(to, bucket, project, hostname, target, path=None):
     backup_list = latest_backups(bucket, project, hostname, target, path)
     x = []
     for backupname, remote_src in backup_list:
-        # actung! the 'path or backupname' is switching between using a specific given filename or the one 
         local_dest = join(to, path or backupname)
         LOG.info("downloading s3 file %r to %r", remote_src, local_dest)
         x.append(download(bucket, remote_src, local_dest))

--- a/ubr/s3.py
+++ b/ubr/s3.py
@@ -204,7 +204,7 @@ def upload_backup(bucket, backup_results, project, hostname, remove=True):
 
 ##
 
-def download_from_s3(bucket, remote_src, local_dest):
+def download(bucket, remote_src, local_dest):
     "remote_src is the s3 key. local_dest is a path to a file on the local filesystem"
     remote_src = remote_src.lstrip('/')
     obj = s3_file(bucket, remote_src)
@@ -291,8 +291,9 @@ def latest_backups(bucket, project, hostname, target, backupname=None):
 def download_latest_backup(to, bucket, project, hostname, target, path=None):
     backup_list = latest_backups(bucket, project, hostname, target, path)
     x = []
-    for backuptype, remote_src in backup_list:
-        local_dest = join(to, backuptype)
+    for backupname, remote_src in backup_list:
+        # actung! the 'path or backupname' is switching between using a specific given filename or the one 
+        local_dest = join(to, path or backupname)
         LOG.info("downloading s3 file %r to %r", remote_src, local_dest)
-        x.append(download_from_s3(bucket, remote_src, join(to, backuptype)))
+        x.append(download(bucket, remote_src, local_dest))
     return x

--- a/ubr/tests/__init__.py
+++ b/ubr/tests/__init__.py
@@ -1,0 +1,2 @@
+import logging
+logging.disable(logging.CRITICAL)

--- a/ubr/tests/test_s3.py
+++ b/ubr/tests/test_s3.py
@@ -182,7 +182,7 @@ class Download(BaseCase):
 
         # download to local
         expected_destination = join(self.expected_output_dir, filename)
-        s3.download_from_s3(self.s3_backup_bucket, key, expected_destination)
+        s3.download(self.s3_backup_bucket, key, expected_destination)
         self.assertTrue(os.path.exists(expected_destination))
 
     def test_download_nonexistant_file(self):
@@ -194,7 +194,7 @@ class Download(BaseCase):
         self.assertFalse(s3.s3_file_exists(s3obj))
 
         # attempt to download to local
-        self.assertRaises(AssertionError, s3.download_from_s3, self.s3_backup_bucket, key, self.expected_output_dir)
+        self.assertRaises(AssertionError, s3.download, self.s3_backup_bucket, key, self.expected_output_dir)
 
     def test_find_latest_file(self):
         "a backup can be uploaded to s3 and then detected as the latest and downloaded"

--- a/ubr/tgz_target.py
+++ b/ubr/tgz_target.py
@@ -37,7 +37,7 @@ def unpack(archive):
     # not great. check modtime as well?
     return [(f, os.path.isfile(f)) for f in filter(os.path.isfile, file_listing)]
 
-def backup(path_list, destination):
+def backup(path_list, destination, prompt=False):
     """does a regular file_backup and then tars and gzips the results.
     the name of the resulting file is 'archive.tar.gz'"""
     destination = os.path.abspath(destination)
@@ -79,7 +79,7 @@ def backup(path_list, destination):
         'output': [output_path]
     }
 
-def restore(path_list, backup_dir):
+def restore(path_list, backup_dir, prompt=False):
     """assumes a file called 'archive.tar.gz' is in the given directory and that all
     the paths to the files within that tar.gz file are """
     filename = filename_for_paths(path_list)

--- a/ubr/utils.py
+++ b/ubr/utils.py
@@ -1,3 +1,4 @@
+import sys
 import os, subprocess
 from datetime import datetime
 import errno
@@ -131,6 +132,52 @@ def pairwise(lst):
     # taken from: http://stackoverflow.com/questions/4628290/pairs-from-single-list
     iterator = iter(lst)
     return izip(iterator, iterator)
+
+def enumerated(lst):
+    return dict(zip(range(1, len(lst) + 1), lst))
+
+def isint(x):
+    try:
+        int(x)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+def choose(prompt, choices, label_fn=None):
+    try:
+        if label_fn:
+            labels = zip(choices, map(label_fn, choices)) # ll: [(/foo/bar/baz, baz), (/foo/bar/bup, bup)]
+        else:
+            labels = zip(choices, choices)
+        idx = enumerated(choices) # ll: {1: /foo/bar/baz, 2: /foo/bar/bup}
+
+        while True:
+            # present menu
+            for i, pair in enumerate(labels):
+                print '%s: %s' % (i + 1, pair[1])
+            print
+
+            # prompt user
+            uin = raw_input(prompt)
+
+            # hygeine
+            if not uin or not uin.strip():
+                print 'a choice is required (ctrl-c to quit)'
+                continue
+            if not isint(uin):
+                print 'a -numeric- choice is required (ctrl-c to quit)'
+                continue
+            uin = int(uin)
+            if uin not in idx:
+                print 'a choice between 1 and %s is required (ctrl-c to quit)' % len(choices)
+                continue
+
+            # all good,
+            return idx[uin]
+
+    except KeyboardInterrupt:
+        print
+        sys.exit(1)
 
 
 from contextlib import contextmanager


### PR DESCRIPTION
* we have the same database with different names that ubr can download, but can't find to restore [fixed]
* we have silent failures on failure-to-restore [fixed]
* added support for a `--prompt` parameter to be passed to ubr. it's not quite the guided backup/restore I always saw being useful, it is a start.