### PR TITLE
Remove GTID from MySQL backup for compatibility with RDS on 5.7.23

### DIFF
--- a/ubr/mysql_target.py
+++ b/ubr/mysql_target.py
@@ -145,6 +145,7 @@ def dump(db, output_path, **kwargs):
     -p%(pass)s \
     --single-transaction \
     --skip-dump-date \
+    --set-gtid-purged=OFF \
     %(dbname)s | gzip > %(path)s"""
         % args
     )


### PR DESCRIPTION
See https://github.com/elifesciences/issues/issues/5136

Manually tested from `prod` towards `continuumtest`.