### PR TITLE
Feature: quieten progress meter

### DIFF
--- a/.test.sh
+++ b/.test.sh
@@ -7,6 +7,8 @@ pyflakes ubr/
 args="$@"
 module=""
 if [ ! -z "$args" ]; then
+    # like this for pytest:
+    # ./ubr/tests/test_main.py::ParseArgs::test_download_adhoc_args
     module="$args"
 fi
 

--- a/ubr/conf.py
+++ b/ubr/conf.py
@@ -122,6 +122,10 @@ def var(envname, cfgpath, default):
 # config
 #
 
+# CLI argument parsing uses the values in this map as defaults
+# tests and other non-standard entry points should use the values in
+# this map if parsed CLI arguments are not available
+DEFAULT_CLI_OPTS = {"progress_bar": True, "prompt": False}
 
 # which S3 bucket should ubr upload backups to/restore backups from?
 BUCKET = "elife-app-backups"
@@ -176,4 +180,4 @@ REPORT_FILE_BLACKLIST = [
 ]
 
 # number of days between now and the last backup before it's considered a problem
-REPORT_PROBLEM_THRESHOLD = 2 # days
+REPORT_PROBLEM_THRESHOLD = 2  # days

--- a/ubr/file_target.py
+++ b/ubr/file_target.py
@@ -47,7 +47,7 @@ def wrangle_files(path_list):
     return new_path_list
 
 
-def backup(path_list, destination, prompt=False):
+def backup(path_list, destination, opts):
     """embarassingly simple 'copy each of the files specified
     to new destination, ignoring the common parents'"""
     LOG.debug("given paths %s with destination %s", path_list, destination)
@@ -74,7 +74,7 @@ def _restore(path, backup_dir):
     return (path, retcode == 0)
 
 
-def restore(path_list, backup_dir, prompt=False):
+def restore(path_list, backup_dir, opts):
     """how do we restore files? we rsync the target from the input dir.
 
     the 'backup_dir' is the dir we read backups from with the given path_list providing further path information

--- a/ubr/main.py
+++ b/ubr/main.py
@@ -178,15 +178,13 @@ def download_from_s3(hostname, path_list, opts):
                     )
             else:
                 # no paths specified, download all paths for hostname+target
-                path = None
                 s3.download_latest_backup(
                     download_dir,
                     conf.BUCKET,
                     project,
                     hostname,
                     target,
-                    path,
-                    opts["progress_bar"],
+                    progress_bar=opts["progress_bar"],
                 )
 
         results.append((descriptor, download_dir))

--- a/ubr/mysql_target.py
+++ b/ubr/mysql_target.py
@@ -136,7 +136,7 @@ def dump(db, output_path, **kwargs):
     args = defaults(db, path=output_path, **kwargs)
     # --skip-dump-date # suppresses the 'Dump completed on <YMD HMS>'
     # at the bottom of each dump file, defeating duplicate checking
-    
+
     # THEORY
     #
     # The MySQL server binary log) contains all events that describe database changes.
@@ -203,7 +203,7 @@ def _backup(path, destination):
     return dump(path, output_path)
 
 
-def backup(path_list, destination, prompt=False):
+def backup(path_list, destination, opts):
     "dumps a list of databases and database tables"
     retval = utils.system("mkdir -p %s" % destination)
     if not retval == 0:
@@ -230,5 +230,5 @@ def _restore(db, backup_dir):
         return (db, False)
 
 
-def restore(db_list, backup_dir, prompt=False):
+def restore(db_list, backup_dir, opts):
     return {"output": [_restore(db, backup_dir) for db in db_list]}

--- a/ubr/psql_target.py
+++ b/ubr/psql_target.py
@@ -178,7 +178,7 @@ def _backup(dbname, destination):
     return output_path
 
 
-def backup(path_list, destination=None, prompt=False):
+def backup(path_list, destination, opts):
     destination = destination or conf.WORKING_DIR
     destination = os.path.abspath(destination)
     utils.system("mkdir -p %s" % destination)
@@ -206,11 +206,12 @@ def backup_missing_prompt_user(dbname, dump_path):
     return utils.choose("choose: ", other_files, os.path.basename)
 
 
-def _restore(dbname, backup_dir, prompt):
+def _restore(dbname, backup_dir, opts):
     "look for a backup of $dbname in $backup_dir and restore it"
     try:
         backup_dir = backup_dir or conf.WORKING_DIR
         dump_path = join(backup_dir, backup_name(dbname))
+        prompt = opts["prompt"]
         if prompt and not os.path.exists(dump_path):
             dump_path = backup_missing_prompt_user(dbname, dump_path)
         ensure(
@@ -227,5 +228,5 @@ def _restore(dbname, backup_dir, prompt):
         return (dbname, False)
 
 
-def restore(path_list, backup_dir, prompt=True):
-    return {"output": [_restore(db, backup_dir, prompt) for db in path_list]}
+def restore(path_list, backup_dir, opts):
+    return {"output": [_restore(db, backup_dir, opts) for db in path_list]}

--- a/ubr/report.py
+++ b/ubr/report.py
@@ -135,6 +135,6 @@ def check(hostname, path_list=None):
             backup_list = parse_prefix_list(path_list)
             for backup in backup_list:
                 old_backup(backup) and problems.append(backup)
-                #problems.append(backup)
+                # problems.append(backup)
     problems and print_report(problems)
     return problems

--- a/ubr/s3.py
+++ b/ubr/s3.py
@@ -159,9 +159,11 @@ class ProgressPercentage(object):
             percentage = (self._seen_so_far / self._size) * 100
             self.done = percentage == 100
             sys.stdout.write(
-                "\r%s  %s / %s  (%.2f%%)        "
+                "\r%s  %s / %s  (%.2f%%)"
                 % (self._filename, self._seen_so_far, self._size, percentage)
             )
+            if self.done:
+                sys.stdout.write("\n")
             sys.stdout.flush()
 
 

--- a/ubr/s3.py
+++ b/ubr/s3.py
@@ -12,16 +12,11 @@ LOG = logging.getLogger(__name__)
 
 def remove_targets(path_list, rooted_at=conf.WORKING_DIR):
     "deletes the list of given paths if the path starts with the given root (default /tmp/)."
-    return list(
-        map(
-            os.unlink,
-            [
-                p
-                for p in list(filter(os.path.isfile, path_list))
-                if p.startswith(rooted_at)
-            ],
-        )
-    )
+    return [
+        os.unlink(p)
+        for p in filter(os.path.isfile, path_list)
+        if p.startswith(rooted_at)
+    ]
 
 
 #

--- a/ubr/s3.py
+++ b/ubr/s3.py
@@ -221,11 +221,11 @@ def verify_file(filename, bucket, key):
     return True
 
 
-def upload_to_s3(bucket, src, dest):
+def upload_to_s3(bucket, src, dest, progress_bar=True):
     LOG.info("attempting to upload %r to s3://%s/%s", src, bucket, dest)
-    inst = ProgressPercentage(src)
+    inst = ProgressPercentage(src) if progress_bar else None
     s3_conn().upload_file(src, bucket, dest, Callback=inst)
-    ensure(inst.done, "failed to complete uploading to s3")
+    progress_bar and ensure(inst.done, "failed to complete uploading to s3")
     ensure(
         verify_file(src, bucket, dest),
         "local file doesn't match results uploaded to s3 (content md5 or content length difference)",
@@ -233,7 +233,9 @@ def upload_to_s3(bucket, src, dest):
     return dest
 
 
-def upload_backup(bucket, backup_results, project, hostname, remove=True):
+def upload_backup(
+    bucket, backup_results, project, hostname, remove=True, progress_bar=True
+):
     """uploads the results of processing a backup.
     `backup_results` should be a dictionary of targets with their results as values.
     each value will have a 'output' key with the outputs for that target.
@@ -244,7 +246,7 @@ def upload_backup(bucket, backup_results, project, hostname, remove=True):
     upload_targets = list(filter(os.path.exists, utils.flatten(upload_targets)))
 
     path_list = [
-        upload_to_s3(bucket, src, s3_key(project, hostname, src))
+        upload_to_s3(bucket, src, s3_key(project, hostname, src), progress_bar)
         for src in upload_targets
     ]
     # TODO: consider moving this into `main`
@@ -256,7 +258,7 @@ def upload_backup(bucket, backup_results, project, hostname, remove=True):
 ##
 
 
-def download(bucket, remote_src, local_dest):
+def download(bucket, remote_src, local_dest, progress_bar=True):
     "remote_src is the s3 key. local_dest is a path to a file on the local filesystem"
     remote_src = remote_src.lstrip("/")
     obj = s3_file(bucket, remote_src)
@@ -264,8 +266,13 @@ def download(bucket, remote_src, local_dest):
     msg = "key %r in bucket %r doesn't exist or we have no access to it. cannot download file."
     ensure(s3_file_exists(obj), msg % (remote_src, bucket))
 
-    inst = DownloadProgressPercentage("s3://%(bucket)s/%(remote_src)s" % locals())
     utils.mkdir_p(os.path.dirname(local_dest))
+
+    inst = (
+        DownloadProgressPercentage("s3://%(bucket)s/%(remote_src)s" % locals())
+        if progress_bar
+        else None
+    )
     s3_conn().download_file(bucket, remote_src, local_dest, Callback=inst)
     return local_dest
 
@@ -347,11 +354,13 @@ def latest_backups(bucket, project, hostname, target, backupname=None):
     return [(backupnom, sorted(pb)[-1]) for backupnom, pb in filename_idx.items()]
 
 
-def download_latest_backup(to, bucket, project, hostname, target, path=None):
+def download_latest_backup(
+    to, bucket, project, hostname, target, path=None, progress_bar=True
+):
     backup_list = latest_backups(bucket, project, hostname, target, path)
-    x = []
+    results = []
     for backupname, remote_src in backup_list:
         local_dest = join(to, path or backupname)
         LOG.info("downloading s3 file %r to %r", remote_src, local_dest)
-        x.append(download(bucket, remote_src, local_dest))
-    return x
+        results.append(download(bucket, remote_src, local_dest, progress_bar))
+    return results

--- a/ubr/tests/test_file_target.py
+++ b/ubr/tests/test_file_target.py
@@ -1,10 +1,11 @@
 import os, shutil, tempfile
-from ubr import main, utils, file_target
+from ubr import main, utils, file_target, conf
 from .base import BaseCase
 
 
 class TestFileBackup(BaseCase):
     def setUp(self):
+        self.default_opts = conf.DEFAULT_CLI_OPTS
         self.expected_output_dir = "/tmp/foo"
 
     def tearDown(self):
@@ -30,7 +31,9 @@ class TestFileBackup(BaseCase):
             }
         }
 
-        output = main.backup(descriptor, output_dir=self.expected_output_dir)
+        output = main.backup(
+            descriptor, output_dir=self.expected_output_dir, opts=self.default_opts
+        )
         self.assertEqual(expected_output, output)
         self.assertTrue(utils.dir_exists(self.expected_output_dir))
         # test all of the files exist
@@ -53,7 +56,9 @@ class TestFileBackup(BaseCase):
             }
         }
 
-        output = main.backup(descriptor, output_dir=self.expected_output_dir)
+        output = main.backup(
+            descriptor, output_dir=self.expected_output_dir, opts=self.default_opts
+        )
         self.assertEqual(expected_output, output)
         # test all of the files exist
         for path in output["files"]["output"]:
@@ -77,7 +82,9 @@ class TestFileBackup(BaseCase):
                 ],
             }
         }
-        output = main.backup(descriptor, output_dir=self.expected_output_dir)
+        output = main.backup(
+            descriptor, output_dir=self.expected_output_dir, opts=self.default_opts
+        )
         self.assertEqual(expected_output, output)
         # test all of the files exist
         for path in output["files"]["output"]:
@@ -105,7 +112,9 @@ class TestFileBackup(BaseCase):
                 ],
             }
         }
-        output = main.backup(descriptor, output_dir=self.expected_output_dir)
+        output = main.backup(
+            descriptor, output_dir=self.expected_output_dir, opts=self.default_opts
+        )
         self.assertEqual(expected_output, output)
         # test all of the files exist
         for path in output["files"]["output"]:
@@ -151,6 +160,7 @@ class TestFileBackup(BaseCase):
 
 class TestFileRestore(BaseCase):
     def setUp(self):
+        self.default_opts = conf.DEFAULT_CLI_OPTS
         self.expected_output_dir = os.path.join("/tmp/", utils.ymdhms())
 
     def tearDown(self):
@@ -167,7 +177,9 @@ class TestFileRestore(BaseCase):
 
         # backup the fixture copy
         descriptor = {"files": [fixture_copy]}
-        main.backup(descriptor, output_dir=self.expected_output_dir)
+        main.backup(
+            descriptor, output_dir=self.expected_output_dir, opts=self.default_opts
+        )
 
         # overwrite our fixture copy with some garbage
         open(fixture_copy, "w").write("fooooooooooooooooooobar")
@@ -175,7 +187,9 @@ class TestFileRestore(BaseCase):
         self.assertNotEqual(md5, bad_md5)
 
         # restore our fixture copy
-        main.restore(descriptor, backup_dir=self.expected_output_dir)
+        main.restore(
+            descriptor, backup_dir=self.expected_output_dir, opts=self.default_opts
+        )
         self.assertEqual(open(fixture, "r").read(), open(fixture_copy, "r").read())
         restored_md5 = utils.generate_file_md5(fixture_copy)
         self.assertEqual(md5, restored_md5)

--- a/ubr/tests/test_s3.py
+++ b/ubr/tests/test_s3.py
@@ -1,6 +1,6 @@
 import os, time, uuid
 from os.path import join
-from ubr import main, mysql_target, s3, tgz_target, utils
+from ubr import main, mysql_target, s3, tgz_target, utils, conf
 from datetime import datetime
 from .base import BaseCase
 
@@ -119,6 +119,7 @@ class One(BaseCase):
 
 class Upload(BaseCase):
     def setUp(self):
+        self.default_opts = conf.DEFAULT_CLI_OPTS
         self.expected_output_dir, self.rmtmpdir = utils.tempdir()
         self.s3_backup_bucket = "elife-app-backups-test"
         self.project_name = "_test"
@@ -137,7 +138,9 @@ class Upload(BaseCase):
         "the results of a backup are uploaded to s3"
         fixture = os.path.join(self.fixture_dir, "img1.png")
         descriptor = {"tar-gzipped": [fixture, os.path.join(self.fixture_dir, "*/**")]}
-        results = main.backup(descriptor, output_dir=self.expected_output_dir)
+        results = main.backup(
+            descriptor, output_dir=self.expected_output_dir, opts=self.default_opts
+        )
 
         s3.upload_backup(
             self.s3_backup_bucket, results, self.project_name, self.hostname
@@ -156,7 +159,9 @@ class Upload(BaseCase):
         # two things to upload
         descriptor = {"tar-gzipped": [fixture], "mysql-database": [self.project_name]}
 
-        results = main.backup(descriptor, output_dir=self.expected_output_dir)
+        results = main.backup(
+            descriptor, output_dir=self.expected_output_dir, opts=self.default_opts
+        )
         uploaded_keys = s3.upload_backup(
             self.s3_backup_bucket, results, self.project_name, self.hostname
         )
@@ -173,7 +178,9 @@ class Upload(BaseCase):
         "after a successful upload to s3, whatever was uploaded is removed"
         fixture = os.path.join(self.fixture_dir, "img1.png")
         descriptor = {"tar-gzipped": [fixture]}
-        results = main.backup(descriptor, output_dir=self.expected_output_dir)
+        results = main.backup(
+            descriptor, output_dir=self.expected_output_dir, opts=self.default_opts
+        )
 
         s3.upload_backup(
             self.s3_backup_bucket, results, self.project_name, self.hostname
@@ -188,6 +195,7 @@ class Download(BaseCase):
         self.project_name = "-test"
         self.s3_backup_bucket = "elife-app-backups-test"
         self.hostname = "testmachine"
+        self.default_opts = conf.DEFAULT_CLI_OPTS
         self.expected_output_dir, self.rmtmpdir = utils.tempdir()
         s3.s3_delete_folder_contents(self.s3_backup_bucket, self.project_name)
 
@@ -243,7 +251,9 @@ class Download(BaseCase):
         descriptor = {"tar-gzipped": paths}
 
         # backup+upload
-        results = main.backup(descriptor, output_dir=self.expected_output_dir)
+        results = main.backup(
+            descriptor, output_dir=self.expected_output_dir, opts=self.default_opts
+        )
         s3.upload_backup(
             self.s3_backup_bucket, results, self.project_name, self.hostname
         )
@@ -272,7 +282,9 @@ class Download(BaseCase):
         "a backup can be uploaded to s3 and then detected as the latest and downloaded"
         # do the backup
         descriptor = {"mysql-database": ["_test"]}
-        results = main.backup(descriptor, output_dir=self.expected_output_dir)
+        results = main.backup(
+            descriptor, output_dir=self.expected_output_dir, opts=self.default_opts
+        )
         s3.upload_backup(
             self.s3_backup_bucket, results, self.project_name, self.hostname
         )
@@ -303,7 +315,9 @@ class Download(BaseCase):
         descriptor = {"tar-gzipped": [fixture, os.path.join(self.fixture_dir, "*/**")]}
 
         # do backup1
-        results = main.backup(descriptor, output_dir=self.expected_output_dir)
+        results = main.backup(
+            descriptor, output_dir=self.expected_output_dir, opts=self.default_opts
+        )
         s3.upload_backup(
             self.s3_backup_bucket, results, self.project_name, self.hostname
         )
@@ -313,7 +327,9 @@ class Download(BaseCase):
         time.sleep(1)
 
         # do backup2
-        results2 = main.backup(descriptor, output_dir=self.expected_output_dir)
+        results2 = main.backup(
+            descriptor, output_dir=self.expected_output_dir, opts=self.default_opts
+        )
         s3.upload_backup(
             self.s3_backup_bucket, results2, self.project_name, self.hostname
         )
@@ -350,7 +366,9 @@ class Download(BaseCase):
         descriptor = {"tar-gzipped": paths}
 
         # backup + upload
-        results = main.backup(descriptor, output_dir=self.expected_output_dir)
+        results = main.backup(
+            descriptor, output_dir=self.expected_output_dir, opts=self.default_opts
+        )
         s3.upload_backup(
             self.s3_backup_bucket, results, self.project_name, self.hostname
         )
@@ -373,6 +391,8 @@ class Download(BaseCase):
         os.system("rm %s" % os.path.abspath(fixture2))
         self.assertFalse(os.path.exists(fixture))
         self.assertFalse(os.path.exists(fixture2))
-        results = main.restore(descriptor, backup_dir=expected_download_dir)
+        results = main.restore(
+            descriptor, backup_dir=expected_download_dir, opts=self.default_opts
+        )
         self.assertTrue(os.path.exists(fixture))
         self.assertTrue(os.path.exists(fixture2))

--- a/ubr/tgz_target.py
+++ b/ubr/tgz_target.py
@@ -45,7 +45,7 @@ def unpack(archive):
     return [(f, os.path.isfile(f)) for f in filter(os.path.isfile, file_listing)]
 
 
-def backup(path_list, destination, prompt=False):
+def backup(path_list, destination, opts):
     """does a regular file_backup and then tars and gzips the results.
     the name of the resulting file is 'archive.tar.gz'"""
     destination = os.path.abspath(destination)
@@ -89,7 +89,7 @@ def backup(path_list, destination, prompt=False):
     return {"output": [output_path]}
 
 
-def restore(path_list, backup_dir, prompt=False):
+def restore(path_list, backup_dir, opts):
     """assumes a file called 'archive.tar.gz' is in the given directory and that all
     the paths to the files within that tar.gz file are """
     filename = filename_for_paths(path_list)

--- a/ubr/utils.py
+++ b/ubr/utils.py
@@ -116,6 +116,10 @@ def first(lst):
         return None
 
 
+def subdict(data, key_list):
+    return {key: val for key, val in data.items() if key in key_list}
+
+
 def rest(lst):
     return lst[1:]
 


### PR DESCRIPTION
* replaced `prompt` with `opts`, a map of options whose defaults are defined in `conf.py`
* removed many of the optional/default parameters so that they must now be passed in explicitly. This leads to less ambiguity (good long term) at the expense of convenience and brevity (good short term).
* removed whitespace at the end of the progress bar output. it was deliberate, tricking my terminal to do something at the time.
* added a new line after progress meter output so position of shell prompt is reset
* added new parameters `--progress-bar` and `--no-progress-bar` that enable/disable the upload/download progress bar (default enabled)