### PR TITLE
Feature: adds some more files to ignore to report blacklist

### DIFF
--- a/ubr/conf.py
+++ b/ubr/conf.py
@@ -177,6 +177,9 @@ REPORT_FILE_BLACKLIST = [
     "archive-d162efcb.tar.gz",  # elife-metrics, old-style backup
     "archive-b40e0f85.tar.gz",  # journal-cms, old-style backup
     "elifedashboardprod-psql.gz",  # elife-dashboard, old-style backup
+    "articlescheduler-psql.gz", # elife-dashboard/article-scheduler, once-off/ad-hoc article-scheduler backup
+    "archive-59001402.tar.gz", # peerscout, adhoc files backup
+    "peerscoutprod-psql.gz", # peerscout, adhoc database upload
 ]
 
 # number of days between now and the last backup before it's considered a problem


### PR DESCRIPTION
fyi @giorgiosironi 

these files were uploaded during the dismantling of peerscout and the RDS upgrade of elife-dashboard and don't need to be flagged by the `check-all` report